### PR TITLE
ci: added support for building PRs

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This change allows PRs submitted from forked repos to be picked up by the CI.

See the documentation: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#on