### PR TITLE
chore: Bumps [guava](https://github.com/google/guava) from 29-jre to 30.1.1-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
             <!-- used for general utilities -->
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>29.0-jre</version>
+            <version>30.1.1-jre</version>
         </dependency>
 
         <!-- test dependencies -->


### PR DESCRIPTION
Updated to address an identified issue
-   `io`: Deprecated  `Files.createTempDir()`. ([fec0dbc](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)) ([CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908); continuing discussion in  [#4011](https://github.com/google/guava/issues/4011))

### Guava Changelog

-   Increased the aggressiveness of  [Guava 30.1](https://github.com/google/guava/releases/tag/v30.1)'s warning log message for running  `guava-android`  under a Java 7 VM. (Android VMs are unaffected.) If the warning  _itself_  causes you trouble, you can eliminate it by silencing the logger for  `com.google.common.base.Preconditions`  (which is used  _only_  for this warning). This warning prepares for  [removing support for Java 7 in 2021](https://github.com/google/guava/issues/5269). Please report any problems. We have tried to make the warning as safe as possible, but anytime a common library logs, especially as aggressively as we do in this new release, there is the potential for  [`NullPointerException`](https://stackoverflow.com/a/41017717/28465)  or even  [deadlock](https://stackoverflow.com/a/48009613/28465). (To be clear, Guava will not log under Java 8 or Android, but it will under Java 7.) ([00c25e9](https://github.com/google/guava/commit/00c25e9b1194e1792da848852d214639d9de59b7))
-   `cache`: Fixed compatibility between  `asMap().compute(...)`  and a load. ([42bf4f4](https://github.com/google/guava/commit/42bf4f4eb7d299d635838296e322ec7e1e77a440))
-   `cache`: Added  `@CheckReturnValue`  to some APIs. ([a5ef129](https://github.com/google/guava/commit/a5ef129ffc4e4d5a19f38660058ae79f42627136))
-   `collect`: Added  `@DoNotCall`  to the mutator methods on immutable types ([6ae9532](https://github.com/google/guava/commit/6ae9532d11b871ea9d8edd691cf7f64f35add6f0))
-   `hash`: Removed  `@Beta`  from  `HashCode`. ([2c9f161](https://github.com/google/guava/commit/2c9f161e10ed4f4568c67cbeb47f3f1f4b3d9c08))
-   `io`: Removed  `@Beta`  from  `CountingOutputStream`.
([d394bac](https://github.com/google/guava/commit/d394bac847467039530f514f880ecca27263d0ff))i
-   If you use guava-android in an Android project (as opposed to from a Java VM), you will need to  [enable desugaring of Java 8  _language features_](https://developer.android.com/studio/write/java8-support.html#supported_features)  if you have not already done so. (And if you are releasing an Android  _library_, then anyone who uses that library will also have to enable desugaring.) We expect for nearly all Android projects to have already enabled desugaring. But if this causes problems for you, please let us know on  [issue #5358](https://github.com/google/guava/issues/5358). The purpose of this change is to detect potential problems for users now so that we can plan to use Java 8 language features in our implementation later this year.
-   Introduced a warning log message when running  `guava-android`  under a Java 7 VM. (Android VMs are unaffected, aside from the need to use desugaring, described in the previous bullet.) This warning is not  _guaranteed_  to be logged when running under Java 7, so please don't rely on it as your only warning about future problems. If the warning  _itself_  causes you trouble, you can eliminate it by silencing the logger for  `com.google.common.base.MoreObjects$ToStringHelper`  (which is used  _only_  for this warning). This warning prepares for  [removing support for Java 7 in 2021](https://github.com/google/guava/issues/5269). Please report any problems. We have tried to make the warning as safe as possible, but anytime a common library logs, there is the potential for  [`NullPointerException`](https://stackoverflow.com/a/41017717/28465)  or even  [deadlock](https://stackoverflow.com/a/48009613/28465). (To be clear, Guava will  _not_  log under Java 8 or Android, but it  _may_  log under Java 7.) ([dc52e6e](https://github.com/google/guava/commit/dc52e6e385fc9f0571dbd046d8ce5bf1a1c1f5cd))
    -   Note that we subsequently made this warning more aggressive in  [Guava 30.1.1](https://github.com/google/guava/releases/tag/v30.1.1), including changing the logger it uses to  `com.google.common.base.Preconditions`.
-   `base`: Deprecated  `StandardSystemProperty.JAVA_EXT_DIRS`. We do not plan to remove the API, but note that, under recent versions of Java, that property always has a value of  `null`. ([38abf07](https://github.com/google/guava/commit/38abf0777224de8fd0ac98b1488bef4195141d12))
-   `net`: Added  `HttpHeaders`  constants for  `Origin-Isolation`  and  `X-Request-ID`. ([a48fb4f](https://github.com/google/guava/commit/a48fb4f72490f99a5f62586b2d7468661dca35d1),  [8319d20](https://github.com/google/guava/commit/8319d201cd4db01220fc4733a37b5e1ee6f608e1))
-   `reflect`: Added  `ClassInfo.isTopLevel()`. ([4106272](https://github.com/google/guava/commit/410627262beccfab185209f0d2e7126177dba7c8))
-   `util.concurrent`: Added  `ClosingFuture.submitAsync(AsyncClosingCallable)`. ([c5e2d8d](https://github.com/google/guava/commit/c5e2d8d5cb30b1cd73fa0e86af161e140d772e03))
-   [Guava types can no longer be sent over GWT-RPC.](https://groups.google.com/d/msg/guava-announce/zHZTFg7YF3o/rQNnwdHeEwAJ)  Even the earlier, temporary way to reenable support (`guava.gwt.emergency_reenable_rpc`) no longer has an effect. ([0cb89dd](https://github.com/google/guava/commit/0cb89dd110ce88770207889901e95ea2ac896932))
-   `cache`: Fixed memory leak in  `LocalCache`  under  [j2objc](https://developers.google.com/j2objc). ([5e519d9](https://github.com/google/guava/commit/5e519d91d038636fa5f786908aa856ba5470846d))
-   `collect`: Added two-element  `min`  and  `max`  methods to  `Comparators`. ([958186c](https://github.com/google/guava/commit/958186c07127f1cd9bb9ba82da99da75745766df))
-   `collect`: Removed  `@Beta`  from  `Multimaps.toMultimap`. ([b6b4dc4](https://github.com/google/guava/commit/b6b4dc49b1ccfc4141181b24a26eadc689b48b43))
-   `collect`: Made the set returned by  `ImmutableMap<K, V>.keySet()`  serializable as long as  `K`  is serializable, even if  `V`  is not (and similarly for  `values()`). ([f5a69c3](https://github.com/google/guava/commit/f5a69c33fcbaa2f570f9fc29a2f4dd4431dae264))
-   `collect`: Fixed bug in  `powerSet.equals(otherPowerSet)`  would erroneously return  `false`  if the two power sets' underlying sets were equal but had a different iteration order. ([215b1f0](https://github.com/google/guava/commit/215b1f0dd715d58d61aa31e3a7a8ca4ac48e218a))
-   `collect`: Eliminated  [j2objc](https://developers.google.com/j2objc)  retain-cycle in  `SingletonImmutableBiMap`. ([0ad38b8](https://github.com/google/guava/commit/0ad38b88bd92319508ebc0b28bab5be1fbf1891f))
-   `eventbus`: Prevented  `@Subscribe`  from being applied to a method that takes a primitive, as that will never be called. ([554546c](https://github.com/google/guava/commit/554546c9718a8c0bdae233a4afd5102180ef55ca))
-   `graph`: Made  `Traverser.breadthFirst()`  lazier, and optimized  `Traverser`  more generally. ([32f2d77](https://github.com/google/guava/commit/32f2d770f7117015385083ec6e755336ddf18f21),  [b5210ca](https://github.com/google/guava/commit/b5210ca95c4303bd91fdb9cb1d063f5680183f0b))
-   `graph`: Added  `@DoNotMock`  to  `Traverser`. ([6410f18](https://github.com/google/guava/commit/6410f18c06074e75effb7823c97df98385f822d0))
-   `io`: Deprecated  `Files.createTempDir()`. ([fec0dbc](https://github.com/google/guava/commit/fec0dbc4634006a6162cfd4d0d09c962073ddf40)) ([CVE-2020-8908](https://nvd.nist.gov/vuln/detail/CVE-2020-8908); continuing discussion in  [#4011](https://github.com/google/guava/issues/4011))
-   `io`: Upgraded  `ByteStreams.copy(InputStream, OutputStream)`  to use the faster  `FileChannel`  if possible. ([a1e9a0b](https://github.com/google/guava/commit/a1e9a0bd1260a657f7502e5b81d38dfb818cd1d4))  [update: My mistake: This was  [rolled back](https://github.com/google/guava/commit/e839f94fb4eb1240f10763586aa92a7f701caa89), so it did not make 30.0.]
-   `math`: Added  `roundToDouble`  to  `BigDecimalMath`,  `BigIntegerMath`, and  `LongMath`. ([bee4f3c](https://github.com/google/guava/commit/bee4f3c7ed1c79938a03c6c798a0b5f77b37ace7),  [2b5c096](https://github.com/google/guava/commit/2b5c096ddf412241c320edccd207d089d5b79b21),  [633abf2](https://github.com/google/guava/commit/633abf2c62823421ced4440f0dfe10295d5671e2))
-   `net`: Added  `MediaType`  constants for several font/ types. ([571cf66](https://github.com/google/guava/commit/571cf66bac6840bee7ab9878bb643eb8d758fc90))
-   `net`: Added  `HttpHeaders`  constants for  `Cross-Origin-Embedder-Policy(-Report-Only)?`. ([c3bf731](https://github.com/google/guava/commit/c3bf73187a0863c35101069d3cf10963840bda3d))
-   `testing`: Made  `EqualsTester`  test that non-`String`  objects are not equal to their  `String`  representations. ([c9570ea](https://github.com/google/guava/commit/c9570eae6909040347e1be0260bc1e7ff154ef44))
-   `util.concurrent`: Added  `ClosingFuture`. ([52e048e](https://github.com/google/guava/commit/52e048ed6c7f60505313b5347162dd7f3f38dd80))
-   `util.concurrent`: Removed the deprecated 1-arg  `ServiceManager.addListener(Listener)`. Use the 2-arg  `addListener(Listener, Executor)`  overload, setting the executor to  `directExecutor()`  for equivalent behavior. ([dfb0001](https://github.com/google/guava/commit/dfb00017144bf48c408bc4cfcebadc0a0498dc73))
-   `util.concurrent`: Changed  `AbstractFuture.toString()`  to no longer include the  `toString()`  of the result. ([2ebf27f](https://github.com/google/guava/commit/2ebf27fd45685e7f89bb4aae11e1709d49863717))
-   `util.concurrent`: Added  `awaitTerminationUninterruptibly`. ([f07b954](https://github.com/google/guava/commit/f07b9540dc11c667686cfea24849659decc5a0d8))