### PR TITLE
fix: updated version of com.fasterxml.jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.salesforce</groupId>
     <artifactId>omakase</artifactId>
-    <version>1.7.3-SNAPSHOT</version>
+    <version>1.7.3</version>
 
     <name>Omakase CSS Parser</name>
     <description>Java-based, plugin-oriented CSS3+ parser</description>
@@ -131,7 +131,13 @@
             <!-- used to read xhr json data for prefixes/browsers info -->
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.6.1</version>
+            <version>2.13.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+            <version>2.13.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.salesforce</groupId>
     <artifactId>omakase</artifactId>
-    <version>1.7.3</version>
+    <version>1.7.3-SNAPSHOT</version>
 
     <name>Omakase CSS Parser</name>
     <description>Java-based, plugin-oriented CSS3+ parser</description>

--- a/src/main/java/com/salesforce/omakase/data/PrefixTables.java
+++ b/src/main/java/com/salesforce/omakase/data/PrefixTables.java
@@ -474,6 +474,7 @@ public final class PrefixTables {
         ImmutableTable.Builder<String, Browser, Double> builder = ImmutableTable.builder();
 
         builder.put("selection", Browser.FIREFOX, 61.0);
+        builder.put("placeholder", Browser.IE, 11.0);
         builder.put("placeholder", Browser.EDGE, 17.0);
         builder.put("placeholder", Browser.OPERA, 43.0);
         builder.put("placeholder", Browser.CHROME, 56.0);

--- a/src/main/java/com/salesforce/omakase/data/PrefixTables.java
+++ b/src/main/java/com/salesforce/omakase/data/PrefixTables.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Table;
  * <p>
  * See class com.salesforce.omakase.tools.GeneratePrefixTablesClass for instructions on updating.
  */
+@SuppressWarnings("AutoBoxing")
 public final class PrefixTables {
     static final Table<Property, Browser, Double> PROPERTIES;
     static final Table<Keyword, Browser, Double> KEYWORDS;
@@ -473,7 +474,6 @@ public final class PrefixTables {
         ImmutableTable.Builder<String, Browser, Double> builder = ImmutableTable.builder();
 
         builder.put("selection", Browser.FIREFOX, 61.0);
-        builder.put("placeholder", Browser.IE, 11.0);
         builder.put("placeholder", Browser.EDGE, 17.0);
         builder.put("placeholder", Browser.OPERA, 43.0);
         builder.put("placeholder", Browser.CHROME, 56.0);


### PR DESCRIPTION
Updated to a new version of the `com.fasterxml.jackson libraries` to address [CVE-2022-42004](https://nvd.nist.gov/vuln/detail/CVE-2022-42004).  https://github.com/FasterXML/jackson-databind/issues/3582
    
Cleaned up the code where the jackson is used.